### PR TITLE
fix: tests fail with updated Horde_mail_Rfc822_List

### DIFF
--- a/lib/Horde/Mail/Rfc822/List.php
+++ b/lib/Horde/Mail/Rfc822/List.php
@@ -11,7 +11,6 @@
  * @package   Mail
  */
 
-use \Horde_Mime_Headers_Addresses;
 
 /**
  * Container object for a collection of RFC 822 elements.


### PR DESCRIPTION
Sorry @ralflang, this one slipped under my radar. The `use` statement in line 14 causes a warning:

```
"The use statement with non-compound name 'Horde_Mime_Headers_Addresses' has no effect"
```

The PR fixes it.